### PR TITLE
Added hosted server.php file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 .DS_Store
 ._*
 public/dist/*.js
+public/dist/*.php

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,8 @@ gulp.task('bower', function() {
 gulp.task('install', ['bower', 'dist'], function() {
   gulp.src("./bower_components/network-js/dist/network.min.js")
     .pipe(gulp.dest("./public/dist"));
+  gulp.src("./bower_components/network-js/server/server.php")
+    .pipe(gulp.dest("./public/dist"));
 });
 
 gulp.task('dist', function() {

--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -1,7 +1,7 @@
 var _bwBenchmark = window._bwBenchmark || {
   config: {
     delay: 1000, // wait XXms until start
-    bwjs: 'dev.videodesk.com/cyrille/network/js/network.min.js',
+    bwjs: '/dist/network.min.js',
     endpoint: '/api/bandwidth'
   },
   // various flags, has to be true when ready js, flash ...

--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -14,7 +14,7 @@ var _bwBenchmark = window._bwBenchmark || {
       var net = new Network({
         // If you define a value at the top level of the object,
         // it will be applied to every module.
-        endpoint: _bwBenchmark.makeURL('dev.videodesk.com/cyrille/network/server/server.php'),
+        endpoint: _bwBenchmark.makeURL('/dist/server.php'),
         download: {
           measures: 5,
           attempts: 3,


### PR DESCRIPTION
Updated the gulpfile to pull it directly from the bower-components into the /dist/ directory so that it can have requests sent to the same host. Executing sample.html on a local server means the speeds will be logged as (understandably) super fast.
